### PR TITLE
Adjust Naming and Remove Objective C Prefixes

### DIFF
--- a/Example/JustTrack.xcodeproj/project.pbxproj
+++ b/Example/JustTrack.xcodeproj/project.pbxproj
@@ -50,8 +50,6 @@
 		21675A35E21330467F875074 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		273A64F5DDAC33D55C7BE4A3 /* Pods-JustTrack_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JustTrack_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-JustTrack_Tests/Pods-JustTrack_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		4544CED3F31AEB9E0E041E76 /* JustTrack.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = JustTrack.podspec; path = ../JustTrack.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		483FC80E1DCCF18B008E2EE0 /* Trackers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Trackers.swift; sourceTree = "<group>"; };
-		483FC8101DD09CCC008E2EE0 /* Events.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Events.swift; sourceTree = "<group>"; };
 		4ACC5FA321CD52C8330640C9 /* Pods_Example_with_Objective_C.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example_with_Objective_C.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4CA4E1D9F2BACAD9A21D947C /* Pods-JustTrack_Example_ObjC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JustTrack_Example_ObjC.debug.xcconfig"; path = "Pods/Target Support Files/Pods-JustTrack_Example_ObjC/Pods-JustTrack_Example_ObjC.debug.xcconfig"; sourceTree = "<group>"; };
 		587548F5EB6E75F385206CFC /* Pods-JustTrack_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JustTrack_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-JustTrack_Example/Pods-JustTrack_Example.debug.xcconfig"; sourceTree = "<group>"; };
@@ -61,8 +59,6 @@
 		607FACDA1AFB9204008FA782 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		607FACDC1AFB9204008FA782 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		607FACDF1AFB9204008FA782 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
-		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		607FACEB1AFB9204008FA782 /* TrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerTests.swift; sourceTree = "<group>"; };
 		695000F9344F9959D5739C1B /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		8BDBAFDA2677AEAF650C3BDC /* Pods-JustTrack_Example_ObjC.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JustTrack_Example_ObjC.release.xcconfig"; path = "Pods/Target Support Files/Pods-JustTrack_Example_ObjC/Pods-JustTrack_Example_ObjC.release.xcconfig"; sourceTree = "<group>"; };
 		92C2380C0281280B47E02DF4 /* Pods-Example with Objective-C.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example with Objective-C.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Example with Objective-C/Pods-Example with Objective-C.debug.xcconfig"; sourceTree = "<group>"; };
@@ -114,7 +110,6 @@
 				C8566BE21E293F8500CC27E3 /* JEEventsGenerator */,
 				607FACF51AFB993E008FA782 /* Podspec Metadata */,
 				607FACD21AFB9204008FA782 /* Example for JustTrack */,
-				607FACE81AFB9204008FA782 /* Tests */,
 				607FACD11AFB9204008FA782 /* Products */,
 				C7FDF60032E4F6772636D32B /* Frameworks */,
 				78EEC4026664FC2BF79F01FB /* Pods */,
@@ -151,25 +146,6 @@
 			isa = PBXGroup;
 			children = (
 				607FACD41AFB9204008FA782 /* Info.plist */,
-			);
-			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		607FACE81AFB9204008FA782 /* Tests */ = {
-			isa = PBXGroup;
-			children = (
-				607FACEB1AFB9204008FA782 /* TrackerTests.swift */,
-				483FC8101DD09CCC008E2EE0 /* Events.swift */,
-				483FC80E1DCCF18B008E2EE0 /* Trackers.swift */,
-				607FACE91AFB9204008FA782 /* Supporting Files */,
-			);
-			path = Tests;
-			sourceTree = "<group>";
-		};
-		607FACE91AFB9204008FA782 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				607FACEA1AFB9204008FA782 /* Info.plist */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -539,6 +515,7 @@
 				DEVELOPMENT_TEAM = ZKPN288GRK;
 				INFOPLIST_FILE = JustTrack/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MARKETING_VERSION = 2.0.0;
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = com.justeat.JustTrack;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -554,6 +531,7 @@
 				DEVELOPMENT_TEAM = ZKPN288GRK;
 				INFOPLIST_FILE = JustTrack/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MARKETING_VERSION = 2.0.0;
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = com.justeat.JustTrack;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Example/JustTrack/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/JustTrack/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -2,37 +2,52 @@
   "images" : [
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "29x29"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "29x29"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "40x40"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/Example/JustTrack/Info.plist
+++ b/Example/JustTrack/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.4</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Example/JustTrack/TrackingEvents.swift
+++ b/Example/JustTrack/TrackingEvents.swift
@@ -2,7 +2,7 @@
 
 /*example
 
-@objcMembers public class JEEventExample: NSObject, JEEvent {
+public class JEEventExample: NSObject, JEEvent {
     public let name: String = "example"
 
     public var payload: Payload {
@@ -40,58 +40,25 @@
 import Foundation
 import JustTrack
 
-@objcMembers public class JEEventTap: NSObject, JEEvent {
-    public let name: String = "Tap"
+public class JEEventNoPayload: NSObject, JEEvent {
+    public let name: String = "NoPayload"
 
     public var payload: Payload {
-        return [
-            kElementName: elementName == "" ? NSNull() : elementName as NSString
-        ]
+        return [:]
     }
 
     public var registeredTrackers: [String] {
         return ["console", "Firebase"]
     }
 
-    private let kElementName = "elementName"
+    
 
-    public var elementName: String = ""
+    
 
-    public init(elementName: String) {
-        super.init()
-        self.elementName = elementName
-    }
+    //MARK: Payload not configured
 }
 
-@objcMembers public class JEEventViewScreen: NSObject, JEEvent {
-    public let name: String = "ViewScreen"
-
-    public var payload: Payload {
-        return [
-            kScreenName: screenName == "" ? NSNull() : screenName as NSString, 
-            kScreenData: screenData == "" ? NSNull() : screenData as NSString
-        ]
-    }
-
-    public var registeredTrackers: [String] {
-        return ["console", "Firebase"]
-    }
-
-    private let kScreenName = "screenName"
-    private let kScreenData = "screenData"
-
-    public var screenName: String = ""
-    public var screenData: String = ""
-
-    public init(screenName: String,
-                screenData: String) {
-        super.init()
-        self.screenName = screenName
-        self.screenData = screenData
-    }
-}
-
-@objcMembers public class JEEventExample: NSObject, JEEvent {
+public class JEEventExample: NSObject, JEEvent {
     public let name: String = "example"
 
     public var payload: Payload {
@@ -124,25 +91,30 @@ import JustTrack
     }
 }
 
-@objcMembers public class JEEventNoPayload: NSObject, JEEvent {
-    public let name: String = "NoPayload"
+public class JEEventTap: NSObject, JEEvent {
+    public let name: String = "Tap"
 
     public var payload: Payload {
-        return [:]
+        return [
+            kElementName: elementName == "" ? NSNull() : elementName as NSString
+        ]
     }
 
     public var registeredTrackers: [String] {
         return ["console", "Firebase"]
     }
 
-    
+    private let kElementName = "elementName"
 
-    
+    public var elementName: String = ""
 
-    //MARK: Payload not configured
+    public init(elementName: String) {
+        super.init()
+        self.elementName = elementName
+    }
 }
 
-@objcMembers public class JEEventUser: NSObject, JEEvent {
+public class JEEventUser: NSObject, JEEvent {
     public let name: String = "User"
 
     public var payload: Payload {
@@ -172,5 +144,33 @@ import JustTrack
         self.action = action
         self.response = response
         self.extra = extra
+    }
+}
+
+public class JEEventViewScreen: NSObject, JEEvent {
+    public let name: String = "ViewScreen"
+
+    public var payload: Payload {
+        return [
+            kScreenName: screenName == "" ? NSNull() : screenName as NSString, 
+            kScreenData: screenData == "" ? NSNull() : screenData as NSString
+        ]
+    }
+
+    public var registeredTrackers: [String] {
+        return ["console", "Firebase"]
+    }
+
+    private let kScreenName = "screenName"
+    private let kScreenData = "screenData"
+
+    public var screenName: String = ""
+    public var screenData: String = ""
+
+    public init(screenName: String,
+                screenData: String) {
+        super.init()
+        self.screenName = screenName
+        self.screenData = screenData
     }
 }

--- a/Example/JustTrack/ViewController.swift
+++ b/Example/JustTrack/ViewController.swift
@@ -26,7 +26,7 @@ class ViewController: UIViewController {
         trackingService.trackEvent(JEEventNoPayload())
     }
     
-    func  configureJustTrack() -> JETracking {
+    func configureJustTrack() -> JETracking {
         let jeTracker: JETracking = JETracking.sharedInstance
         jeTracker.deliveryType = .batch
         jeTracker.logClosure = { (logString: String, logLevel: JETrackingLogLevel) -> Void in

--- a/JustTrack.podspec
+++ b/JustTrack.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'JustTrack'
-  s.version          = '3.3.2'
+  s.version          = '4.0.0'
   s.summary          = 'The Just Eat solution to better manage the analytics tracking on iOS and improve the relationship with your BI team.'
 
   s.description      = <<-DESC

--- a/JustTrack/Classes/JustTrack/JEEvent.swift
+++ b/JustTrack/Classes/JustTrack/JEEvent.swift
@@ -14,7 +14,7 @@ public enum JEEventEncodingKey: String {
     case trackers
 }
 
-@objc public protocol JEEvent {
+public protocol JEEvent {
     var name: String { get }
     var payload: Payload { get }
     var registeredTrackers: [String] { get }

--- a/JustTrack/Classes/JustTrack/JETracker.swift
+++ b/JustTrack/Classes/JustTrack/JETracker.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-@objc public protocol JETracker {
+public protocol JETracker {
     var name: String { get }
     func trackEvent(_ name: String, payload: Payload, completion: (_ success: Bool) -> Void )
 }

--- a/JustTrack/Classes/JustTrack/JETracking.swift
+++ b/JustTrack/Classes/JustTrack/JETracking.swift
@@ -18,7 +18,7 @@ import Foundation
 /// ````
 ///
 /// - seealso: `logClosure`
-@objc public enum JETrackingLogLevel: NSInteger {
+public enum JETrackingLogLevel: NSInteger {
     case verbose
     case debug
     case info
@@ -33,7 +33,7 @@ import Foundation
 /// ```
 ///
 /// - seealso: `dispatchInterval`
-@objc public enum JETrackingDeliveryType: NSInteger {
+public enum JETrackingDeliveryType: NSInteger {
     /// Will wait before dispatching events to trackers based on `dispatchInterval`.
     case batch
     
@@ -46,13 +46,13 @@ import Foundation
 /// ````
 /// case consoleLogger
 /// ````
-@objc public enum JETrackerType : NSInteger {
+public enum JETrackerType : NSInteger {
     case consoleLogger
 }
 
 /// JETracking manages the mapping and dispatching of events to trackers.
 /// - TODO: More elaborate documentation for this with example usage.
-@objcMembers public class JETracking: NSObject {
+public class JETracking: NSObject {
     
     // MARK: - Internal Properties
     

--- a/JustTrack/Classes/JustTrack/Trackers/JETrackerConsole.swift
+++ b/JustTrack/Classes/JustTrack/Trackers/JETrackerConsole.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 
-@objcMembers
 class JETrackerConsole: NSObject, JETracker {
     
     // MARK: - JETracker protocol implementation

--- a/JustTrack/JEEventsGenerator/JEEventListTemplate.jet
+++ b/JustTrack/JEEventsGenerator/JEEventListTemplate.jet
@@ -2,7 +2,7 @@
 
 /*example
 
-@objcMembers public class JEEventExample: NSObject, JEEvent {
+public class JEEventExample: NSObject, JEEvent {
     public let name: String = "example"
 
     public var payload: Payload {

--- a/JustTrack/JEEventsGenerator/JEEventTemplate.jet
+++ b/JustTrack/JEEventsGenerator/JEEventTemplate.jet
@@ -1,4 +1,4 @@
-@objcMembers public class JEEvent<*!event_name*>: NSObject, JEEvent {
+public class JEEvent<*!event_name*>: NSObject, JEEvent {
     public let name: String = "<*event_name*>"
 
     public var payload: Payload {

--- a/JustTrack/JEEventsGenerator/main.swift
+++ b/JustTrack/JEEventsGenerator/main.swift
@@ -200,7 +200,7 @@ private func generateEvents(_ events: [String : AnyObject]) throws -> NSString {
          let key1 : String
          let key2 : String
          */
-        let eventKeysVars: String = try generateEventKeysVars(cleanKeys)
+        let eventKeysVars: String = try generateEventKeysVariables(cleanKeys)
         structString = replacePlaceholder(structString, placeholder: "<*\(JETemplatePlaceholder.keysVars.rawValue)*>", value: eventKeysVars)
         
         /*
@@ -294,7 +294,7 @@ private func generateEventKeysNames(_ keys: [String]) throws -> String {
     return resultArray.count > 0 ? resultArray.joined(separator: "\n    ") : ""
 }
 
-private func generateEventKeysVars(_ keys: [String]) throws -> String {
+private func generateEventKeysVariables(_ keys: [String]) throws -> String {
     
     let structVarTemplate: String = try stringFromTemplate(JETemplate.keyVar.rawValue)
     var resultArray: [String] = Array()

--- a/JustTrack/JEEventsGenerator/test.txt
+++ b/JustTrack/JEEventsGenerator/test.txt
@@ -1,4 +1,4 @@
-@objcMembers class JEEvent<*!event_name*>: NSObject, JEEvent {
+class JEEvent<*!event_name*>: NSObject, JEEvent {
 
     //JEEvent protocol
     let name: String = "<*event_name*>"
@@ -60,7 +60,7 @@ self.test3 = test3
 
 
 
-@objcMembers public class JEEventExample: NSObject, JEEvent {
+public class JEEventExample: NSObject, JEEvent {
     public let name: String = "example"
 
     public var payload: [String : String]? {

--- a/JustTrack/UnitTests/MockTrackers.swift
+++ b/JustTrack/UnitTests/MockTrackers.swift
@@ -21,7 +21,7 @@ final class MockTracker: NSObject, JETracker {
     }
 }
 
-final class SomeOtherMockTracker: NSObject, JETracker {
+final class AnotherMockTracker: NSObject, JETracker {
     let name = "SomeOtherMockTracker"
     var didTrackExpectation: XCTestExpectation?
     var trackEventInvocationCount = 0

--- a/JustTrack/UnitTests/TestEvents.swift
+++ b/JustTrack/UnitTests/TestEvents.swift
@@ -8,7 +8,7 @@
 import Foundation
 import JustTrack
 
-@objc final class JEEventExample: NSObject, JEEvent {
+final class JEEventExample: NSObject, JEEvent {
     
     //JEEvent protocol
     public let name: String = "example"
@@ -42,7 +42,7 @@ import JustTrack
     }
 }
 
-@objc final class JEEventInvalid: NSObject, JEEvent {
+final class JEEventInvalidExample: NSObject, JEEvent {
     
     //JEEvent protocol
     public let name: String = ""

--- a/JustTrack/UnitTests/TrackerTests.swift
+++ b/JustTrack/UnitTests/TrackerTests.swift
@@ -15,7 +15,7 @@ class TrackerTests: XCTestCase {
     // MARK: - Stubs / Mocks
     
     var tracker1:MockTracker?
-    var tracker2:SomeOtherMockTracker?
+    var tracker2:AnotherMockTracker?
     
     // MARK: - Setup
     override func setUp() {
@@ -27,7 +27,7 @@ class TrackerTests: XCTestCase {
         }
         
         tracker1 = MockTracker()
-        tracker2 = SomeOtherMockTracker()
+        tracker2 = AnotherMockTracker()
     }
     
     // MARK: - Teardown
@@ -216,7 +216,7 @@ class TrackerTests: XCTestCase {
         let eventExpectation = expectation(description: "Service should not attempt to track invalid event.")
         
         // GIVEN an INVALID event (event without name and / or trackers)
-        let event = JEEventInvalid()
+        let event = JEEventInvalidExample()
         
         // AND a tracker service using some tracker
         trackerService.loadCustomTracker(tracker1!)

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ An Event is made of:
 ##### Generated Swift Class
 
 ```Swift
-@objcMembers public class JEEventUser: NSObject, JEEvent {
+public class JEEventUser: NSObject, JEEvent {
 
     // JEEvent protocol
     public let name: String = "User"


### PR DESCRIPTION
Adjusts Naming and Remove Objective C Prefixes. This introduces a breaking change for Objective C consumers. As such, the version number has been bumped in line with semantic versioning. A leftover test Directory with no associated files has also been removed.