### PR TITLE
Add sorted(by:) Method in order to preserve order of Event creation

### DIFF
--- a/Example/JustTrack/TrackingEvents.swift
+++ b/Example/JustTrack/TrackingEvents.swift
@@ -73,80 +73,6 @@ public class JEEventExample: NSObject, JEEvent {
     }
 }
 
-public class JEEventUser: NSObject, JEEvent {
-    public let name: String = "User"
-
-    public var payload: Payload {
-        return [
-            kAction: action == "" ? NSNull() : action as NSString, 
-            kResponse: response == "" ? NSNull() : response as NSString, 
-            kExtra: extra == "" ? NSNull() : extra as NSString
-        ]
-    }
-
-    public var registeredTrackers: [String] {
-        return ["console", "Firebase"]
-    }
-
-    private let kAction = "action"
-    private let kResponse = "response"
-    private let kExtra = "extra"
-
-    public var action: String = ""
-    public var response: String = ""
-    public var extra: String = ""
-
-    public init(action: String,
-                response: String,
-                extra: String) {
-        super.init()
-        self.action = action
-        self.response = response
-        self.extra = extra
-    }
-}
-
-public class JEEventNoPayload: NSObject, JEEvent {
-    public let name: String = "NoPayload"
-
-    public var payload: Payload {
-        return [:]
-    }
-
-    public var registeredTrackers: [String] {
-        return ["console", "Firebase"]
-    }
-
-    
-
-    
-
-    //MARK: Payload not configured
-}
-
-public class JEEventTap: NSObject, JEEvent {
-    public let name: String = "Tap"
-
-    public var payload: Payload {
-        return [
-            kElementName: elementName == "" ? NSNull() : elementName as NSString
-        ]
-    }
-
-    public var registeredTrackers: [String] {
-        return ["console", "Firebase"]
-    }
-
-    private let kElementName = "elementName"
-
-    public var elementName: String = ""
-
-    public init(elementName: String) {
-        super.init()
-        self.elementName = elementName
-    }
-}
-
 public class JEEventViewScreen: NSObject, JEEvent {
     public let name: String = "ViewScreen"
 
@@ -183,4 +109,78 @@ public class JEEventViewScreen: NSObject, JEEvent {
         self.screenDataVar = screenDataVar
         self.screenDataVarSetting = screenDataVarSetting
     }
+}
+
+public class JEEventUser: NSObject, JEEvent {
+    public let name: String = "User"
+
+    public var payload: Payload {
+        return [
+            kAction: action == "" ? NSNull() : action as NSString, 
+            kResponse: response == "" ? NSNull() : response as NSString, 
+            kExtra: extra == "" ? NSNull() : extra as NSString
+        ]
+    }
+
+    public var registeredTrackers: [String] {
+        return ["console", "Firebase"]
+    }
+
+    private let kAction = "action"
+    private let kResponse = "response"
+    private let kExtra = "extra"
+
+    public var action: String = ""
+    public var response: String = ""
+    public var extra: String = ""
+
+    public init(action: String,
+                response: String,
+                extra: String) {
+        super.init()
+        self.action = action
+        self.response = response
+        self.extra = extra
+    }
+}
+
+public class JEEventTap: NSObject, JEEvent {
+    public let name: String = "Tap"
+
+    public var payload: Payload {
+        return [
+            kElementName: elementName == "" ? NSNull() : elementName as NSString
+        ]
+    }
+
+    public var registeredTrackers: [String] {
+        return ["console", "Firebase"]
+    }
+
+    private let kElementName = "elementName"
+
+    public var elementName: String = ""
+
+    public init(elementName: String) {
+        super.init()
+        self.elementName = elementName
+    }
+}
+
+public class JEEventNoPayload: NSObject, JEEvent {
+    public let name: String = "NoPayload"
+
+    public var payload: Payload {
+        return [:]
+    }
+
+    public var registeredTrackers: [String] {
+        return ["console", "Firebase"]
+    }
+
+    
+
+    
+
+    //MARK: Payload not configured
 }

--- a/JustTrack/JEEventsGenerator/main.swift
+++ b/JustTrack/JEEventsGenerator/main.swift
@@ -177,7 +177,7 @@ private func generateEvents(_ events: [String : AnyObject]) throws -> NSString {
     let resultString: NSMutableString = NSMutableString(string: structListTemplateString)
     var structsArray: [String] = Array()
     
-    for eventName: String in events.keys {
+    for eventName: String in events.keys.sorted(by: >) {
         
         let eventDic: [String : AnyObject]? = events[eventName] as? [String : AnyObject]
         


### PR DESCRIPTION
This PR Implements the sorted(by:) method in order to preserve the order of Tracking Event Creation across runs. Making it easier to spot and compare changes. 